### PR TITLE
Simplify soft assertion example and narrative

### DIFF
--- a/exercises/03.assertions/05.problem.soft-assertions/README.mdx
+++ b/exercises/03.assertions/05.problem.soft-assertions/README.mdx
@@ -8,7 +8,7 @@ For example, let's say you are testing a user subscription service. There, one o
 user.cancelSubscription()
 
 expect(user.subscription.state).toBe('cancelled')
-expect(user.subscription.endsAt).toBe('2025-01-01T00:00:00.000Z')
+expect(user.subscription.endsAt).toBe('2026-01-01T00:00:00.000Z')
 ```
 
 There are two criteria to assume the correct cancellation:

--- a/exercises/03.assertions/05.problem.soft-assertions/src/plans.ts
+++ b/exercises/03.assertions/05.problem.soft-assertions/src/plans.ts
@@ -26,11 +26,7 @@ export class Plan {
 		}
 
 		const today = new Date()
-		today.setUTCDate(1)
-
-		if (today.getUTCMonth() === 0) {
-			today.setUTCFullYear(today.getUTCFullYear() + 1)
-		}
+		today.setUTCMonth(today.getUTCMonth() + 1, 1)
 
 		this.endsAt = today.toISOString()
 	}

--- a/exercises/03.assertions/05.problem.soft-assertions/src/user.test.ts
+++ b/exercises/03.assertions/05.problem.soft-assertions/src/user.test.ts
@@ -3,7 +3,7 @@ import { UnlimitedPlan } from './plans'
 
 beforeAll(() => {
 	vi.useFakeTimers()
-	vi.setSystemTime(new Date('2025-12-02T00:00:00Z'))
+	vi.setSystemTime(new Date('2025-11-02T00:00:00Z'))
 })
 
 afterAll(() => {

--- a/exercises/03.assertions/05.solution.soft-assertions/README.mdx
+++ b/exercises/03.assertions/05.solution.soft-assertions/README.mdx
@@ -78,13 +78,13 @@ This gives me an overview of the entire system, not just the first failed assert
 		this.state = 'cancelled'
 
 		const today = new Date()
-		today.setUTCDate(1)
-		today.setUTCMonth(
-			today.getUTCMonth() + 1 > 11 ? 0 : today.getUTCMonth() + 1,
-		)
-
-		if (today.getUTCMonth() === 0) {
-			today.setUTCFullYear(today.getUTCFullYear() + 1)
+		switch (this.kind) {
+			case "monthly":
+				today.setUTCMonth(today.getUTCMonth() + 1, 1)
+				break;
+			case "yearly":
+				today.setUTCFullYear(today.getUTCFullYear() + 1, 0, 1)
+				break;
 		}
 
 		this.endsAt = today.toISOString()

--- a/exercises/03.assertions/05.solution.soft-assertions/README.mdx
+++ b/exercises/03.assertions/05.solution.soft-assertions/README.mdx
@@ -69,7 +69,7 @@ Received: "2025-12-01T00:00:00.000Z"
 
 This gives me an overview of the entire system, not just the first failed assertion. Equipped with that knowledge, I can fix the issue as a whole instead of solving each failed assertion individually.
 
-```ts filename=src/plans.ts add=6,10-12
+```ts filename=src/plans.ts add=6,9-16
 	public cancel() {
 		if (this.state !== 'active') {
 			return

--- a/exercises/03.assertions/05.solution.soft-assertions/src/plans.ts
+++ b/exercises/03.assertions/05.solution.soft-assertions/src/plans.ts
@@ -26,11 +26,7 @@ export class Plan {
 		}
 
 		const today = new Date()
-		today.setUTCDate(1)
-
-		if (today.getUTCMonth() === 0) {
-			today.setUTCFullYear(today.getUTCFullYear() + 1)
-		}
+		today.setUTCMonth(today.getUTCMonth() + 1, 1)
 
 		this.endsAt = today.toISOString()
 	}


### PR DESCRIPTION
## Problem
When doing the exercise on soft assertions, I found it confusing how to correct the source code, because there were multiple bugs and it wasn't clear what the solution wanted us to do.

The bugs were:
- monthly subscriptions were not handled properly
- yearly subscriptions were not handled at all

Also, the solution was a bit overcomplicated (`setUTCMonth` handles year changes, i.e you can do `today.setUTCMonth(20)` to set it to 20 months after the first day of that year), which I think brings the attention away from vitest and soft assertions

## Proposed solution
Let's simplify the logic so that the bug is a bit more straightforward to fix:
- monthly subscriptions are handled properly, but not yearly subscriptions
- change the test system date to make it obvious that we increased the month and not the year